### PR TITLE
Remove submodule checkout

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,6 +30,8 @@ install:
   - set PYTHON_ROOT=C:\Python37-x64
   # Add neccessary paths to PATH variable
   - set PATH=%cd%;C:\ninja-build;%PYTHON_ROOT%;%PYTHON_ROOT%\Scripts;%PATH%
+  # Add llvm-config.exe to the path
+  - set PATH=%PATH%;C:\Libraries\llvm-5.0.0\bin
   # Install meson
   - pip install meson
   # Enable Visual Studio 2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,8 @@ cache:
   - 'C:\Users\appveyor\.cargo'
 
 install:
+  # Checkout submodules
+  - git submodule update --init --recursive
   # Download ninja
   - mkdir C:\ninja-build
   - ps: (new-object net.webclient).DownloadFile('https://github.com/mesonbuild/cidata/raw/master/ninja.exe', 'C:\ninja-build\ninja.exe')

--- a/build.rs
+++ b/build.rs
@@ -6,13 +6,6 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 
 fn main() {
-    // Prepare source.
-    if !Path::new("libui/.git").exists() {
-        let _ = Command::new("git")
-            .args(&["submodule", "update", "--init", "--recursive"])
-            .status();
-    }
-
     // Generate bindings.
     let bindings = bindgen::Builder::default()
         .header("libui/ui.h")

--- a/build.rs
+++ b/build.rs
@@ -125,10 +125,17 @@ fn detect_windres_msvc() {
             .expect("Error: finding Win SDK errored out");
 
         if let Some(sdk_info) = sdk_info {
-            std::env::set_var(
-                "WINDRES",
-                sdk_info.installation_folder().join("bin/x86/rc.exe"),
-            )
+            let sdk_folder = sdk_info.installation_folder();
+
+            let windres_path = match env::var("CARGO_CFG_TARGET_ARCH") {
+                Ok(ref arch) if arch == "x86_64" => sdk_folder.join("bin/x64/rc.exe"),
+                Ok(ref arch) if arch == "x86" => sdk_folder.join("bin/x86/rc.exe"),
+                Ok(other) => panic!{"Unsupported target architecture: {}", other},
+                Err(e) => panic!{"Error getting target arch {}", e}
+            };
+
+            // double-quote path to escape spaces
+            std::env::set_var("WINDRES", format!(r#""{}""#, windres_path.display()))
         }
     }
 }


### PR DESCRIPTION
Crates on crates.io are not pulled as git repositories. This causes
a) the path libui/.git to never exist, and, subsequently
b) git erroring out with:

```
Caused by:
  process didn't exit successfully: `libui-rs-static/target/debug/build/libui-sys-086734ec98b21422/build-script-build` (exit code: 101)
--- stderr
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

This error is usually silently swallowed, but crops up when the build fails
for other reasons (e.g. build without meson installed).

For dependent crates in cargo builds this change is backwards compatible, since
cargo/crates.io checks out submodules by default. For direct builds from the
git source the submodule checkout should be at the descretion of the user. This
also removes the git dependency in the build.